### PR TITLE
Track changes when editing a content package

### DIFF
--- a/app/assets/javascripts/pig/unsaved-changes.js
+++ b/app/assets/javascripts/pig/unsaved-changes.js
@@ -6,15 +6,23 @@ function setFormSubmitting() {
 
 $(document).ready(function(){
   if ($('.unsaved-changes').length > 0) {
+    var isDirty = false;
+    $(':input').on("change keyup", function () {
+      isDirty = true;
+      document.title = document.title + "*";
+      $(this).off('change keyup');
+    });
     window.onload = function() {
       window.addEventListener("beforeunload", function (e) {
-        var confirmationMessage = 'It looks like you have been editing something. ';
-        confirmationMessage += 'If you leave before saving, your changes will be lost.';
-        if (formSubmitting) {
-          return undefined;
+        if(isDirty) {
+          var confirmationMessage = 'It looks like you have been editing something. ';
+          confirmationMessage += 'If you leave before saving, your changes will be lost.';
+          if (formSubmitting) {
+            return undefined;
+          }
+          (e || window.event).returnValue = confirmationMessage; //Gecko + IE
+          return confirmationMessage; //Gecko + Webkit, Safari, Chrome etc.
         }
-        (e || window.event).returnValue = confirmationMessage; //Gecko + IE
-        return confirmationMessage; //Gecko + Webkit, Safari, Chrome etc.
       });
     };
   }


### PR DESCRIPTION
When editing a content package, only warn the user when leaving the page if they have made changes
