### PR TITLE
Add ability for developers to delete an alias (inactive) permalinks.

### DIFF
--- a/app/controllers/pig/admin/permalinks_controller.rb
+++ b/app/controllers/pig/admin/permalinks_controller.rb
@@ -1,0 +1,20 @@
+module Pig
+  module Admin
+    class PermalinksController < Pig::Admin::ApplicationController
+      before_action :find_permalink
+      load_and_authorize_resource class: 'Pig::Permalink'
+
+      def destroy
+        @permalink.destroy
+        redirect_to pig.edit_admin_content_package_path(@permalink.resource,
+                                                        notice: t('actions.destroyed', class: Pig::Permalink.model_name.human))
+      end
+
+      private
+
+      def find_permalink
+        @permalink = Pig::Permalink.find_by(full_path: "/#{params[:id]}")
+      end
+    end
+  end
+end

--- a/app/models/pig/ability.rb
+++ b/app/models/pig/ability.rb
@@ -12,6 +12,9 @@ module Pig
       ],
       'Pig::ContentPackage' => [
         :manage_slug
+      ],
+      'Pig::Permalink' => [
+        :destroy
       ]
     }
 
@@ -37,16 +40,25 @@ module Pig
             cannot action, klass.constantize
           end
         end
+        can :destroy, Pig::Permalink do |permalink|
+          permalink.created_at > 1.hour.ago
+        end
       elsif user.role_is?(:editor)
         can [:edit, :update], Pig::ContentPackage, :author_id => user.id
         can [:manage], Pig::ContentPackage
         cannot :destroy,  Pig::ContentPackage
         can [:index, :dashboard, :children], Pig::ContentType
+        can :destroy, Pig::Permalink do |permalink|
+          permalink.created_at > 1.hour.ago
+        end
       elsif user.role_is?(:author)
         can [:edit, :update], Pig::ContentPackage, :author_id => user.id
         can [:index, :show, :activity, :ready_to_review, :search], Pig::ContentPackage
         can [:index, :dashboard, :children], Pig::ContentType
         can :contributor_blog_posts, Pig::ContentPackage
+        can :destroy, Pig::Permalink do |permalink|
+          permalink.created_at > 1.hour.ago
+        end
       end
     end
   end

--- a/app/views/pig/admin/content_packages/_permalinks.html.haml
+++ b/app/views/pig/admin/content_packages/_permalinks.html.haml
@@ -6,5 +6,9 @@
     %label= t('.inactive_permalinks', default: 'Aliases')
     %ul
     - content_package.permalinks.inactive.each do |permalink|
-      %li= link_to permalink.full_path, '' + permalink.full_path, class: "col-primary"
+      %li
+        = link_to permalink.full_path, '' + permalink.full_path, class: "col-primary"
+        - if can?(:destroy, permalink)
+          = link_to pig.admin_permalink_path(permalink), method: 'DELETE', data: { confirm: t('actions.confirm_destroy', class: Pig::Permalink.model_name.human) }, class: 'pull-right' do
+            %i.fa.fa-trash-o
   = form.input :short_permalink_path, prepend: '/', label: 'Add an alias'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,4 @@
+en:
+  actions:
+    confirm_destroy: "Are you sure you want to destroy this %{class}? This action cannot be undone."
+    destroyed: "%{class} destroyed."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,8 @@ Pig::Engine.routes.draw do
     get '/content' => 'content_types#dashboard'
     post '/attachments' => 'attachments#create'
 
+    resources :permalinks, only: [:destroy]
+
     resources :content_packages, except: :show do
       collection do
         get 'filter/:filter' => 'content_packages#index', :as => 'filter'

--- a/features/permalinks.feature
+++ b/features/permalinks.feature
@@ -37,3 +37,42 @@ Scenario: I can not visit an unpublished content package by its permalinks
   Given there is 1 unpublished content package
   When I visit its permalink
   Then I should get a 404
+
+@javascript
+Scenario Outline: I can delete permalinks
+  Given I am logged in as an <role>
+  And there is 1 content package
+  And the content package has an old permalink alias
+  When I visit the content package edit page
+  And I delete the permalink alias
+  Then the permalink alias should be removed
+  Examples:
+    | role      |
+    | developer |
+
+@javascript
+Scenario Outline: I can delete permalinks as an admin when they are new
+  Given I am logged in as an <role>
+  And there is 1 content package
+  And the content package has a new permalink alias
+  When I visit the content package edit page
+  And I delete the permalink alias
+  Then the permalink alias should be removed
+  Examples:
+    | role   |
+    | admin  |
+    | editor |
+    | author |
+
+@javascript
+Scenario Outline: I cannot delete permalinks as an admin when they are an hour old
+  Given I am logged in as an <role>
+  And there is 1 content package
+  And the content package has an old permalink alias
+  When I visit the content package edit page
+  Then I should not be able to delete the permalink alias
+  Examples:
+    | role   |
+    | admin  |
+    | editor |
+    | author |

--- a/features/step_definitions/content_package_steps.rb
+++ b/features/step_definitions/content_package_steps.rb
@@ -382,3 +382,8 @@ When(/^I mark the content package as published$/) do
   visit pig.edit_admin_content_package_path(@content_package)
   select('Published', from: "Status")
 end
+
+When(/^I visit the content package edit page$/) do
+  visit pig.edit_admin_content_package_path(@content_package)
+end
+

--- a/features/step_definitions/permalink_steps.rb
+++ b/features/step_definitions/permalink_steps.rb
@@ -1,0 +1,25 @@
+Given(/^the content package has an old permalink alias$/) do
+ @permalink_alias = FactoryGirl.create(:permalink,
+                                       resource: @content_package,
+                                       created_at: 1.week.ago)
+end
+
+Given(/^the content package has a new permalink alias$/) do
+ @permalink_alias = FactoryGirl.create(:permalink,
+                                       resource: @content_package)
+end
+
+When(/^I delete the permalink alias$/) do
+  click_link 'Meta'
+  page.find(:xpath, "//a[@href='#{pig.admin_permalink_path(@permalink_alias)}']").click
+end
+
+Then(/^the permalink alias should be removed$/) do
+  expect(Pig::Permalink.all).to_not include(@permalink_alias)
+end
+
+
+Then(/^I should not be able to delete the permalink alias$/) do
+  click_link 'Meta'
+  expect{ page.find(:xpath, "//a[@href='#{pig.admin_permalink_path(@permalink_alias)}']") }.to raise_error(Capybara::ElementNotFound)
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,10 +11,220 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150528093861) do
+ActiveRecord::Schema.define(version: 20150608151718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "pig_activity_items", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "resource_id"
+    t.string   "resource_type"
+    t.integer  "parent_resource_id"
+    t.string   "parent_resource_type"
+    t.string   "text"
+    t.datetime "created_at"
+  end
+
+  add_index "pig_activity_items", ["parent_resource_type", "parent_resource_id"], name: "parent_resource_index", using: :btree
+  add_index "pig_activity_items", ["resource_type", "resource_id"], name: "resource_index", using: :btree
+  add_index "pig_activity_items", ["user_id"], name: "index_pig_activity_items_on_user_id", using: :btree
+
+  create_table "pig_content_attributes", force: :cascade do |t|
+    t.integer "content_type_id"
+    t.string  "slug"
+    t.string  "name"
+    t.text    "description"
+    t.string  "field_type"
+    t.integer "limit_quantity"
+    t.string  "limit_unit"
+    t.integer "position",                 default: 0
+    t.boolean "required",                 default: false
+    t.boolean "meta",                     default: false
+    t.string  "meta_tag_name"
+    t.integer "default_attribute_id"
+    t.text    "sir_trevor_settings"
+    t.integer "resource_content_type_id"
+  end
+
+  add_index "pig_content_attributes", ["content_type_id"], name: "index_pig_content_attributes_on_content_type_id", using: :btree
+
+  create_table "pig_content_chunks", force: :cascade do |t|
+    t.integer  "content_package_id"
+    t.integer  "content_attribute_id"
+    t.text     "value"
+    t.text     "html"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "pig_content_chunks", ["content_package_id", "content_attribute_id"], name: "index_content_on_package_attribute", unique: true, using: :btree
+
+  create_table "pig_content_packages", force: :cascade do |t|
+    t.string   "slug"
+    t.string   "name"
+    t.integer  "content_type_id"
+    t.integer  "position",         default: 0
+    t.integer  "parent_id"
+    t.integer  "lft",                                null: false
+    t.integer  "rgt",                                null: false
+    t.integer  "author_id"
+    t.integer  "requested_by_id"
+    t.string   "status",           default: "draft"
+    t.boolean  "logged_in_only",   default: false
+    t.boolean  "hide_from_robots", default: false
+    t.text     "notes"
+    t.date     "due_date"
+    t.integer  "review_frequency"
+    t.date     "next_review"
+    t.date     "publish_at"
+    t.date     "published_at"
+    t.datetime "deleted_at"
+    t.string   "meta_title"
+    t.text     "meta_description"
+    t.string   "meta_keywords"
+    t.string   "meta_image_uid"
+    t.string   "meta_image_name"
+    t.json     "json_content",     default: {},      null: false
+    t.integer  "depth",            default: 0,       null: false
+    t.integer  "children_count",   default: 0,       null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "pig_content_packages", ["lft"], name: "index_pig_content_packages_on_lft", using: :btree
+  add_index "pig_content_packages", ["parent_id"], name: "index_pig_content_packages_on_parent_id", using: :btree
+  add_index "pig_content_packages", ["rgt"], name: "index_pig_content_packages_on_rgt", using: :btree
+  add_index "pig_content_packages", ["slug"], name: "index_pig_content_packages_on_slug", using: :btree
+
+  create_table "pig_content_packages_personas", id: false, force: :cascade do |t|
+    t.integer "content_package_id"
+    t.integer "persona_id"
+  end
+
+  add_index "pig_content_packages_personas", ["content_package_id"], name: "index_pig_content_packages_personas_on_content_package_id", using: :btree
+
+  create_table "pig_content_types", force: :cascade do |t|
+    t.string  "name"
+    t.text    "description"
+    t.boolean "singleton",    default: false
+    t.string  "package_name"
+    t.boolean "viewless",     default: false
+    t.string  "view_name"
+    t.boolean "use_workflow", default: false
+  end
+
+  create_table "pig_meta_data", force: :cascade do |t|
+    t.string   "page_slug"
+    t.string   "title"
+    t.text     "description"
+    t.string   "keywords"
+    t.string   "image_uid"
+    t.string   "image_name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "pig_navigation_items", force: :cascade do |t|
+    t.integer  "parent_id"
+    t.integer  "position",      default: 0
+    t.string   "item_type"
+    t.string   "title"
+    t.text     "description"
+    t.string   "image_uid"
+    t.string   "logo_uid"
+    t.string   "resource_type"
+    t.integer  "resource_id"
+    t.text     "url"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "pig_navigation_items", ["parent_id"], name: "index_pig_navigation_items_on_parent_id", using: :btree
+
+  create_table "pig_permalinks", force: :cascade do |t|
+    t.string   "path"
+    t.string   "full_path"
+    t.integer  "resource_id"
+    t.string   "resource_type"
+    t.boolean  "active",        default: true
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "pig_permalinks", ["full_path"], name: "index_pig_permalinks_on_full_path", using: :btree
+  add_index "pig_permalinks", ["path"], name: "index_pig_permalinks_on_path", using: :btree
+
+  create_table "pig_persona_groups", force: :cascade do |t|
+    t.string   "name"
+    t.integer  "position"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "pig_personas", force: :cascade do |t|
+    t.integer  "group_id"
+    t.string   "name"
+    t.string   "category"
+    t.integer  "age"
+    t.text     "summary"
+    t.text     "benefit_1"
+    t.text     "benefit_2"
+    t.text     "benefit_3"
+    t.text     "benefit_4"
+    t.string   "image_uid"
+    t.string   "file_uid"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "pig_personas", ["group_id"], name: "index_pig_personas_on_group_id", using: :btree
+
+  create_table "pig_resource_tag_categories", force: :cascade do |t|
+    t.integer "tag_category_id"
+    t.integer "taggable_resource_id"
+    t.string  "taggable_resource_type"
+  end
+
+  add_index "pig_resource_tag_categories", ["tag_category_id"], name: "index_pig_resource_tag_categories_on_tag_category_id", using: :btree
+  add_index "pig_resource_tag_categories", ["taggable_resource_id", "taggable_resource_type"], name: "index_resource_id_and_type", using: :btree
+  add_index "pig_resource_tag_categories", ["taggable_resource_id"], name: "index_pig_resource_tag_categories_on_taggable_resource_id", using: :btree
+
+  create_table "pig_sir_trevor_images", force: :cascade do |t|
+    t.text    "image_uid"
+    t.text    "sir_trevor_uid"
+    t.text    "filename"
+    t.integer "content_package_id"
+  end
+
+  create_table "pig_tag_categories", force: :cascade do |t|
+    t.string "name"
+    t.string "slug"
+  end
+
+  create_table "pig_users", force: :cascade do |t|
+    t.string   "first_name"
+    t.string   "last_name"
+    t.string   "bio"
+    t.string   "role"
+    t.boolean  "active",                 default: true
+    t.string   "email",                  default: "",   null: false
+    t.string   "encrypted_password",     default: "",   null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          default: 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
+    t.string   "image_uid"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "pig_users", ["email"], name: "index_pig_users_on_email", unique: true, using: :btree
+  add_index "pig_users", ["reset_password_token"], name: "index_pig_users_on_reset_password_token", unique: true, using: :btree
 
   create_table "taggings", force: :cascade do |t|
     t.integer  "tag_id"

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -69,6 +69,12 @@ FactoryGirl.define do
     user
   end
 
+  factory :permalink, class: Pig::Permalink do
+    sequence(:path) { |n| "foo-#{n}" }
+    sequence(:full_path) { |n| "/foo-#{n}" }
+    active false
+  end
+
   factory :content_package, class: Pig::ContentPackage do
     sequence(:name) {|n| "Content package #{n}"}
     content_type


### PR DESCRIPTION
Admin, Editors and Authors can delete permalinks for up to one hour
after they are created.
