### PR TITLE
links on the front to pages with no permalink throw a routing error.  I

### DIFF
--- a/app/views/pig/admin/content_packages/_content_package.html.haml
+++ b/app/views/pig/admin/content_packages/_content_package.html.haml
@@ -15,7 +15,7 @@
   %td{:class => "td-status td-status-#{content_package.status}"}
     =content_package.due_date.try(:strftime, '%b %d, %Y')
   %td
-    =link_to('View', pig.content_package_path(content_package)) unless content_package.viewless? || content_package.missing_view?
+    =link_to('View', pig.content_package_path(content_package)) unless content_package.viewless? || content_package.missing_view? || content_package.permalink.nil?
   %td
     -if can? :edit, content_package
       =link_to('Edit', pig.edit_admin_content_package_path(content_package))


### PR DESCRIPTION
have added code to work around this for the case I found, which I am not
happy with but this should be a temp solution as the plan is to remove
viewless content packages entirely soon.
