### PR TITLE
Require the faraday typheous adapter to support typheous v0.5

### DIFF
--- a/lib/tasks/pig_tasks.rake
+++ b/lib/tasks/pig_tasks.rake
@@ -2,6 +2,7 @@ require "capybara/dsl"
 require "capybara/poltergeist"
 require 'benchmark'
 require 'typhoeus'
+require 'typhoeus/adapters/faraday'
 
 
 total_time_taken = 0


### PR DESCRIPTION
When trying to run rake tasks in a project using pig it threw the following error:
`[Ethon::Errors::InvalidOption] The option: disable_ssl_peer_verification is invalid`

According to https://github.com/typhoeus/typhoeus/issues/226#issuecomment-9919517 this is due to Faraday not supporting Typhoeus 0.5: "If you want to use Typhoeus 0.5 with Faraday you have to require typhoeus/adapters/faraday." 
