### PR TITLE
Fix bug preventing reordering of content package children

### DIFF
--- a/app/views/pig/admin/content_packages/reorder.html.haml
+++ b/app/views/pig/admin/content_packages/reorder.html.haml
@@ -16,8 +16,8 @@
         %fieldset.inputs
           .controls.sortable
             -@content_package.children.each do |child|
-              .well{:id => "children_ids_#{child.id}"}
+              .well{id: "children_ids_#{child.id}"}
                 =child
         %fieldset.form-actions
-          =link_to('Save order', save_order_content_package_path(@content_package), :method => :put, :class => 'btn btn-success sortable-submit pull-right')
+          =link_to('Save order', pig.save_order_admin_content_package_path(@content_package), method: :put, class: 'btn btn-success sortable-submit pull-right')
           .clearfix

--- a/features/content_packages.feature
+++ b/features/content_packages.feature
@@ -210,3 +210,15 @@ Scenario Outline: I can assign a content package to an author
     | developer |
     | admin     |
     | editor    |
+
+@javascript
+Scenario Outline: I can reorder children of a content package
+  Given I am logged in as an <role>
+  And there is a content package with 3 children
+  When I reorder the children
+  Then the children are reordered
+  Examples:
+    | role      |
+    | developer |
+    | admin     |
+    | editor    |

--- a/features/step_definitions/content_package_steps.rb
+++ b/features/step_definitions/content_package_steps.rb
@@ -32,6 +32,13 @@ Given(/^there is a content package with a parent$/) do
   @content_package = FactoryGirl.create(:content_package, :parent_id => @parent_content_package.id)
 end
 
+Given(/^there is a content package with (\d+) children$/) do |children_count|
+  @content_package = FactoryGirl.create(:content_package)
+  children_count.to_i.times do
+    FactoryGirl.create(:content_package, parent_id: @content_package.id)
+  end
+end
+
 Given(/^(?:there is|I create) a content package with the permalink path "(.*?)"$/) do |permalink|
   FactoryGirl.create(:content_package, :permalink_path => permalink)
 end
@@ -392,4 +399,16 @@ end
 Then(/^I should be on the content package show page$/) do
   expect(page.current_path).
     to eq(pig.content_package_path(@content_package))
+end
+
+When(/^I reorder the children$/) do
+  visit pig.reorder_admin_content_package_path(@content_package)
+  first = find('#children_ids_2')
+  second = find('#children_ids_3')
+  first.drag_to(second)
+  click_link('Save order')
+end
+
+Then(/^the children are reordered$/) do
+  expect(@content_package.children.pluck(:id)).to eq([3,2,4])
 end


### PR DESCRIPTION
due to an incorrect path namespace

```
save_order_content_package_path(@content_package) ->  pig.save_order_admin_content_package_path(@content_package)
```
