### PR TITLE
Add support for apps to add custom field types

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,33 @@ We then have to give Pig the permission to access to the Google analytics API
 2. Click the **admin** tab
 3. Choose the relevant account from the drop down
 4. Add the service account email to the user management with *Read & analyze* privileges
+
+### Custom field types
+Sometimes the predefined field types in Pig (Single line of text, rich text, boolean, etc) aren't enough. The following steps allow creation of custom types.
+
+Add the following line to the Pig config initializer
+
+    config.content_types = { my_custom_field: 'Display name' }
+
+Create 2 new files in your application, the first file defines how the custom field will be rendered when editing the page. Pig uses [formtastic](https://github.com/justinfrench/formtastic) for all its inputs.
+```ruby
+# /app/inputs/my_custom_field_input.rb
+class StoryTagsInput < FormtasticBootstrap::Inputs::SelectInput
+  def input_html_options
+    super.merge(class: "my-custom-input")
+  end
+end
+```
+The second file defines `get/set` for the value of the field.
+
+```ruby
+# /app/types/pig/my_custom_field_type.rb
+module Pig
+  class MyCustomFieldType < Type
+    def get(content_package)
+      super(content_package).do_custom_stuff
+    end
+  end
+end
+```
+#### Thats it!

--- a/app/inputs/rich_redactor_input.rb
+++ b/app/inputs/rich_redactor_input.rb
@@ -1,5 +1,5 @@
 class RichRedactorInput < FormtasticBootstrap::Inputs::TextInput
-    def input_html_options
-      super.merge(:class => "rich-redactor")
-    end
+  def input_html_options
+    super.merge(class: 'rich-redactor')
+  end
 end

--- a/app/models/pig/content_attribute.rb
+++ b/app/models/pig/content_attribute.rb
@@ -23,21 +23,21 @@ module Pig
 
       def field_types
         {
-          :string => 'Single line of text',
-          :text => 'Block of text',
-          :link => 'Link',
-          :image => 'Image',
-          :file => 'File',
-          :embeddable => 'Embeddable content - Flickr, Instagram, Scribd, Slideshare, SoundCloud, Vimeo, YouTube',
-          :tags => 'Tag list',
-          :boolean => 'Check box',
-          :user => "User",
-          :location => "Location",
-          :resource => "Link to content",
-          :rich_content => "Rich Content",
-          :date => "Date",
-          :time => "Time"
-        }
+          string: 'Single line of text',
+          text: 'Block of text',
+          link: 'Link',
+          image: 'Image',
+          file: 'File',
+          embeddable: 'Embeddable content - Flickr, Instagram, Scribd, Slideshare, SoundCloud, Vimeo, YouTube',
+          tags: 'Tag list',
+          boolean: 'Check box',
+          user: 'User',
+          location: 'Location',
+          resource: 'Link to content',
+          rich_content: 'Rich Content',
+          date: 'Date',
+          time: 'Time'
+        }.merge(Pig.configuration.content_types)
       end
 
       def fields_to_duplicate

--- a/lib/generators/pig/templates/pig.rb
+++ b/lib/generators/pig/templates/pig.rb
@@ -17,6 +17,7 @@ Pig.setup do |config|
   # config.redactor_plugins = %w(bufferbuttons video blockQuote)
   # config.basic_redactor_plugins = ['bufferbuttons']
   config.cms_roles = [:developer, :admin, :editor, :author]
+  # config.content_types = {}
   config.homepage = proc { Pig::ContentPackage.find_by slug: 'home' }
   # config.archive_domain = 'http://www.example.com'
   # config.ga_code = 'UA-xxxxxxxx-1'

--- a/lib/pig/config.rb
+++ b/lib/pig/config.rb
@@ -5,6 +5,7 @@ module Pig
                   :basic_redactor_plugins,
                   :redactor_plugins,
                   :cms_roles,
+                  :content_types,
                   :unpublished,
                   :not_found,
                   :additional_stylesheets,
@@ -28,6 +29,7 @@ module Pig
       self.archive_domain = options[:archive_domain] || ''
       self.ga_code = options[:ga_code] || ''
       self.cms_roles = options[:cms_roles] || [:developer, :admin, :editor, :author]
+      self.content_types = options[:content_types] || {}
     end
 
   end


### PR DESCRIPTION
Allow custom field types to be defined in the config initialiser in the format: 
`{ key: :display_name }`

These are then merged with the predefined field types. At run time the corresponding input and type files and looked up via the key defined in the initialiser.

I couldn't think of a decent way to test this, thoughts?
