### PR TITLE
Correctly test for a 200 in the smoke test

### DIFF
--- a/lib/tasks/pig_tasks.rake
+++ b/lib/tasks/pig_tasks.rake
@@ -20,7 +20,7 @@ namespace :pig do
 
       request.on_complete do |response|
         pages_tested += 1
-        success = response.return_code == :ok && !response.body.include?('Pig::') && !(response.body =~ /href="\/\d+"/)
+        success = response.response_code == 200 && !response.body.include?('Pig::') && !(response.body =~ /href="\/\d+"/)
 
         failures << permalink unless success
         total_time_taken += response.total_time


### PR DESCRIPTION
The smoke test never actually tested for a 200 ok response! Ooops
Typheous::Response#return_code returns the value from libcurl, a 404 is considered an fine transfer and so the return_code is :ok

Instead we just ensure the response code is 200!
