### PR TITLE
fix admin edit link for content items

### DIFF
--- a/app/models/pig/concerns/versionable.rb
+++ b/app/models/pig/concerns/versionable.rb
@@ -1,3 +1,7 @@
+# When using versionable the live version published on the site
+# is always the last paper_trail version. The preview version
+# is the canonical non-versioned instance of the model.
+
 module Pig
   module Concerns
     module Versionable
@@ -15,7 +19,8 @@ module Pig
       end
 
       def preview_version
-        self
+        # get the non-versioned model
+        @preview_version ||= self.class.find(id)
       end
 
     end

--- a/app/models/pig/concerns/workflow.rb
+++ b/app/models/pig/concerns/workflow.rb
@@ -62,7 +62,8 @@ module Pig
           update: {
             published: :notify_author_of_publish,
             pending: :ready_to_review
-          }
+          },
+          expiring: {}
         }
         event = transitions[status_was.to_sym][status.to_sym]
         send(event) if event


### PR DESCRIPTION
ensure the canonical object is used in the cancan permissions check and
not the last version generated by paper_trail, as the content package
might have been assigned to a new author since it was last published
