### PR TITLE
Pig use content_for :meta_image

### DIFF
--- a/app/helpers/pig/application_helper.rb
+++ b/app/helpers/pig/application_helper.rb
@@ -38,7 +38,7 @@ module Pig
         meta_hide_from_robots = nil
       end
 
-      meta_image = image || "#{Settings.site_url}#{asset_path(Settings.default_fb_meta_image)}"
+      meta_image = image || content_for(:meta_image) || "#{Settings.site_url}#{asset_path(Settings.default_fb_meta_image)}"
 
       meta_values = [meta_title, meta_description, meta_image, meta_keywords, meta_hide_from_robots]
 


### PR DESCRIPTION
Give views a way to specify what meta_image to use in the same way as
they can currently specify a title or description
