### PR TITLE
Add a leading slash to resource links

### DIFF
--- a/app/types/pig/resource_type.rb
+++ b/app/types/pig/resource_type.rb
@@ -14,7 +14,8 @@ module Pig
       end
       content_package.define_singleton_method("#{@slug}_path") do
         if this.content_value(self).present?
-          Pig::ContentPackage.find(this.content_value(self)).to_param
+          cp_path = Pig::ContentPackage.find(this.content_value(self)).to_param
+          "/#{cp_path}".squeeze "/"
         end
       end
     end

--- a/lib/pig/version.rb
+++ b/lib/pig/version.rb
@@ -1,3 +1,3 @@
 module Pig
-  VERSION = "1.0.5"
+  VERSION = "1.0.6"
 end

--- a/spec/models/pig/content_package_spec.rb
+++ b/spec/models/pig/content_package_spec.rb
@@ -147,7 +147,7 @@ module Pig
       it 'can return the path to the related content package' do
         cp = FactoryGirl.create(:content_package, :permalink_path => "test")
         content_package.resource = cp.id
-        expect(content_package.resource_path).to eq(cp.to_param)
+        expect(content_package.resource_path).to eq("/#{cp.to_param}")
       end
     end
 


### PR DESCRIPTION
When using the Resource content attribute type, only the id of the content
package to link to is stored.
The content package is then decorated with an *_path method which gets the
latest permalink for that content package.

This was returning urls without a leading slash:
    "this-is-an/example/url"
This causes problems as the url is appended to the existing url when linked.

This commit prepends a leading slash to the url to ensure the link can always be
directly linked without any manipulation.
