### PR TITLE
Add #XXX_content_package method to resource types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pig (1.0.7)
+    pig (1.0.8)
       acts-as-taggable-on
       acts_as_commentable
       awesome_nested_set
@@ -84,7 +84,7 @@ GEM
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    autoprefixer-rails (6.4.0.2)
+    autoprefixer-rails (6.4.1.1)
       execjs
     awesome_nested_set (3.1.1)
       activerecord (>= 4.0.0, < 5.1)
@@ -164,7 +164,7 @@ GEM
     erubis (2.7.0)
     ethon (0.9.0)
       ffi (>= 1.3.0)
-    excon (0.51.0)
+    excon (0.52.0)
     execjs (2.7.0)
     extlib (0.9.16)
     factory_girl (4.5.0)
@@ -195,13 +195,13 @@ GEM
       actionpack (>= 3.2.13)
     formtastic-bootstrap (3.1.1)
       formtastic (>= 3.0)
-    geocoder (1.3.7)
+    geocoder (1.4.0)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
-    google-api-client (0.8.6)
-      activesupport (>= 3.2)
+    google-api-client (0.8.7)
+      activesupport (>= 3.2, < 5.0)
       addressable (~> 2.3)
       autoparse (~> 0.3)
       extlib (~> 0.9)
@@ -255,7 +255,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
     ipaddress (0.8.3)
-    jquery-rails (4.1.1)
+    jquery-rails (4.2.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -280,7 +280,7 @@ GEM
     lumberjack (1.0.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
-    memoist (0.14.0)
+    memoist (0.15.0)
     method_source (0.8.2)
     mime-types (2.99.2)
     mini_portile2 (2.1.0)
@@ -304,9 +304,8 @@ GEM
       rack (>= 1.2, < 3)
     orm_adapter (0.5.0)
     os (0.9.6)
-    paper_trail (5.2.0)
+    paper_trail (5.2.2)
       activerecord (>= 3.0, < 6.0)
-      activesupport (>= 3.0, < 6.0)
       request_store (~> 1.1)
     pg (0.18.2)
     pkg-config (1.1.7)
@@ -462,4 +461,4 @@ DEPENDENCIES
   therubyracer
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/types/pig/resource_type.rb
+++ b/app/types/pig/resource_type.rb
@@ -12,9 +12,14 @@ module Pig
       content_package.define_singleton_method("#{@slug}_valid?") do |content_package|
         this.valid?(content_package)
       end
+      content_package.define_singleton_method("#{@slug}_content_package") do
+        if this.content_value(self).present?
+          Pig::ContentPackage.find(this.content_value(self))
+        end
+      end
       content_package.define_singleton_method("#{@slug}_path") do
         if this.content_value(self).present?
-          cp_path = Pig::ContentPackage.find(this.content_value(self)).to_param
+          cp_path = self.send("#{this.slug}_content_package").to_param
           "/#{cp_path}".squeeze "/"
         end
       end

--- a/app/types/pig/type.rb
+++ b/app/types/pig/type.rb
@@ -2,6 +2,8 @@ module Pig
   # Generic type which adds a get and set method to the content package which
   # it decorates
   class Type
+    attr_accessor :slug
+
     def initialize(content_package, slug, field_type)
       @slug = slug
       @field_type = field_type

--- a/spec/models/pig/content_package_spec.rb
+++ b/spec/models/pig/content_package_spec.rb
@@ -149,6 +149,11 @@ module Pig
         content_package.resource = cp.id
         expect(content_package.resource_path).to eq("/#{cp.to_param}")
       end
+      it 'can return the related content package' do
+        cp = FactoryGirl.create(:content_package)
+        content_package.resource = cp.id
+        expect(content_package.resource_content_package).to eq(cp)
+      end
     end
 
     describe 'text attributes' do


### PR DESCRIPTION
Provides quick access from one content package to another in views and
used internally for XXX_path calculation.
