### PR TITLE
Set slug before validation

### DIFF
--- a/app/models/pig/content_attribute.rb
+++ b/app/models/pig/content_attribute.rb
@@ -4,7 +4,7 @@ module Pig
     belongs_to :content_type
     belongs_to :default_attribute, :class_name => 'ContentAttribute'
     after_validation :set_meta_title, :if => :meta?
-    after_validation :set_slug
+    before_validation :set_slug
     validates :slug, :name, :field_type, :presence => true
     begin
       validates :slug, :name,


### PR DESCRIPTION
As a after validation the only way to create content attribute is in
multiple steps with a validate in the middle (new > validate > save) as
create will always fail on a missing slug.  By moving the slug
generation to a before validate we avoid this.
